### PR TITLE
docs: corrected duplicated path in user creation endpoint documentation

### DIFF
--- a/openapi/main.yaml
+++ b/openapi/main.yaml
@@ -13,7 +13,7 @@ tags:
   - name: social-medias
     description: Operations about social medias
 paths:
-  /api/users:
+  /users:
     $ref: './features/user/user-create-path.yaml'
   /users/:id/accounts:
     $ref: './features/user/user-network-find-all.yaml'


### PR DESCRIPTION
Closes #117 

<details open> 
  <summary>
    <b>Feature</b>
  </summary>

removido o /api 

</details>

<details open> 
  <summary>
    <b>Bugfix</b>
  </summary>

- **Description**
  N/A

- **Cause**
  N/A

- **Solution**
N/A
</details>

<details> 
  <summary>
    <b>Changelog</b>
  </summary>
N/A
</details>

<details open> 
  <summary>
    <b>Visual evidences :framed_picture:</b>
  </summary>

</details>

<details open> 
  <summary>
    <b>Checklist</b>
  </summary>

- [x] Issue linked
- [x] Build working correctly
- [ ] Tests created
</details>

<details> 
  <summary>
    <b>Additional info</b>
  </summary>
N/A
</details>
